### PR TITLE
Unable to launch app in iOS simulators on Apple Silicon Machines (M1 Mac) in Flutter 2.5.0

### DIFF
--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -22,5 +22,7 @@ Pod::Spec.new do |s|
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
   s.swift_version = '4.0'
 end


### PR DESCRIPTION
Fix #424

Suggested solution is obtained from https://github.com/CocoaPods/CocoaPods/issues/10104#issuecomment-704862852

This issue has been found since Flutter 2.5.0.