### PR TITLE
Fix Null-Safety error

### DIFF
--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -1567,7 +1567,7 @@ class RtcEngineEventHandler {
         requestToken?.call();
         break;
       case 'AudioVolumeIndication':
-        final list = List<Map>.from(newData[0]);
+        final list = List<Map>.from(newData[0] ?? []);
         var totalVolume;
         // if (kIsWeb || (Platform.isWindows || Platform.isMacOS)) {
 


### PR DESCRIPTION
Fix for when using ```enableAudioVolumeIndication```, null-safety errors are observed at:

https://github.com/AgoraIO/Agora-Flutter-SDK/blob/1b44bcdb534a8acac94daaf1347608b515c9a962/lib/src/events.dart#L1570

